### PR TITLE
disable xdebug profiler until we support it

### DIFF
--- a/src/components/Tabs/PerformanceTab.vue
+++ b/src/components/Tabs/PerformanceTab.vue
@@ -23,13 +23,13 @@
 		<performance-log></performance-log>
 
 		<div tabs="performance">
-			<div class="performance-tabs">
-				<a class="performance-tab" :class="{ 'active': isTabActive('timeline') }" href="#" @click.prevent="showTab('timeline')">Timeline</a>
-				<a class="performance-tab" :class="{ 'active': isTabActive('profiler') }" href="#" @click.prevent="showTab('profiler')">Profiler</a>
-			</div>
+<!--			<div class="performance-tabs">-->
+<!--				<a class="performance-tab" :class="{ 'active': isTabActive('timeline') }" href="#" @click.prevent="showTab('timeline')">Timeline</a>-->
+<!--				<a class="performance-tab" :class="{ 'active': isTabActive('profiler') }" href="#" @click.prevent="showTab('profiler')">Profiler</a>-->
+<!--			</div>-->
 
 			<timeline name="performance" :items="$request.timeline" :tags="timelineTags" v-show="isTabActive('timeline')"></timeline>
-			<profiler v-show="isTabActive('profiler')"></profiler>
+<!--			<profiler v-show="isTabActive('profiler')"></profiler>-->
 		</div>
 	</div>
 </template>


### PR DESCRIPTION
aktuell würde ich die Xdebug Profiler Dinge im Frontend deaktivieren, wir im Backend aktuell nicht den Support anbieten und es aktuell für mich so scheint, dass es in der WebUI von Clockwork noch nen Bug diesbezüglich gibt.

Werde ich genauer analysieren und ggf. mal mit its besprechen.